### PR TITLE
Update peer-dependencies to support Angular 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,14 +70,14 @@
     "rxjs": "^5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.4.2",
-    "typescript": "~2.0.0",
+    "typescript": "^2.0.0",
     "zone.js": "^0.7.6"
   },
   "peerDependencies": {
-    "@angular/core": "^2.4.0",
-    "@angular/http": "^2.4.0",
+    "@angular/core": "^2.4.0 || ^4.0.0",
+    "@angular/http": "^2.4.0 || ^4.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.1.0",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6 || ^0.8.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4804,7 +4804,7 @@ type-is@~1.6.14:
     media-typer "0.3.0"
     mime-types "~2.1.13"
 
-"typescript@>=2.0.0 <2.2.0", typescript@~2.0.0:
+"typescript@>=2.0.0 <2.2.0", typescript@^2.0.0:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.0.10.tgz#ccdd4ed86fd5550a407101a0814012e1b3fac3dd"
 


### PR DESCRIPTION
This will remove dependency warnings when using package with Angular 4